### PR TITLE
Fix/validate

### DIFF
--- a/lua/ddc_source_lsp_setup.lua
+++ b/lua/ddc_source_lsp_setup.lua
@@ -25,6 +25,7 @@ local M = {}
 
 ---@param opt ddc_source_lsp_config
 function M.setup(opt)
+  opt = opt or {}
   vim.validate("opt", opt, "table")
   opt = vim.tbl_extend("force", {}, default_config, opt or {}) --[[@as ddc_source_lsp_config]]
 

--- a/lua/ddc_source_lsp_setup.lua
+++ b/lua/ddc_source_lsp_setup.lua
@@ -26,7 +26,7 @@ local M = {}
 ---@param opt ddc_source_lsp_config
 function M.setup(opt)
   opt = opt or {}
-  vim.validate("opt", opt, "table")
+  vim.validate("opt", opt, "table", true)
   opt = vim.tbl_extend("force", {}, default_config, opt or {}) --[[@as ddc_source_lsp_config]]
 
   if opt.override_capabilities then

--- a/lua/ddc_source_lsp_setup.lua
+++ b/lua/ddc_source_lsp_setup.lua
@@ -25,9 +25,7 @@ local M = {}
 
 ---@param opt ddc_source_lsp_config
 function M.setup(opt)
-  vim.validate({
-    opt = { opt, "t", true },
-  })
+  vim.validate("opt", opt, "table")
   opt = vim.tbl_extend("force", {}, default_config, opt or {}) --[[@as ddc_source_lsp_config]]
 
   if opt.override_capabilities then


### PR DESCRIPTION
Changing `vim.validate` format to new one from deprecated one.
ref: https://neovim.io/doc/user/lua.html#vim.validate()